### PR TITLE
Proposed quote support (#27)

### DIFF
--- a/src/FSharp.Quotations.Evaluator/QuotationsEvaluator.fs
+++ b/src/FSharp.Quotations.Evaluator/QuotationsEvaluator.fs
@@ -144,7 +144,7 @@ module QuotationEvaluationTypes =
         | DerivedPatterns.AndAlso(x1,x2) -> Expression.AndAlso(ConvExpr env x1, ConvExpr env x2) |> asExpr
         | DerivedPatterns.OrElse(x1,x2)  -> Expression.OrElse(ConvExpr env x1, ConvExpr env x2)  |> asExpr
         | Patterns.Value(x,ty)           -> Expression.Constant(x,ty)                            |> asExpr
-        
+
         // REVIEW: exact F# semantics for TypeAs and TypeIs
         | Patterns.Coerce(x,toTy)             -> Expression.TypeAs(ConvExpr env x,toTy) |> asExpr
         | Patterns.TypeTest(x,toTy)           -> Expression.TypeIs(ConvExpr env x,toTy) |> asExpr

--- a/tests/FSharp.Quotations.Evaluator.Tests/Tests.fs
+++ b/tests/FSharp.Quotations.Evaluator.Tests/Tests.fs
@@ -1275,6 +1275,17 @@ let ForLoopTests() =
 
     checkEval "fl2" fl2 (Seq.sum [0..10])
     
+
+[<Test>]
+let QuoteTests() =
+    let quoteChar = <@ <@ 'a' @> @> |> eval
+    let quoteInt = <@ <@ 1 @> @> |> eval
+    let quoteQuoteInt = <@ <@ <@ 1 @> @> @> |> eval
+    test "quoteChar" (quoteChar = <@ 'a' @>)
+    test "quoteInt" (quoteInt = <@ 1 @>)
+    test "quoteQuoteInt" (quoteQuoteInt = <@ <@ 1 @> @>)
+
+
 module CheckedTests = 
     open Microsoft.FSharp.Core.Operators.Checked
           
@@ -1467,6 +1478,8 @@ module ParseTests =
         test "parseUint16" (parseUint16 = 42us)
         test "parseUint32" (parseUint32 = 42u)
         test "parseUint64" (parseUint64 = 42UL)
+
+
 
 module GithubIssues =
     [<Test>]

--- a/tests/FSharp.Quotations.Evaluator.Tests/Tests.fs
+++ b/tests/FSharp.Quotations.Evaluator.Tests/Tests.fs
@@ -1479,8 +1479,6 @@ module ParseTests =
         test "parseUint32" (parseUint32 = 42u)
         test "parseUint64" (parseUint64 = 42UL)
 
-
-
 module GithubIssues =
     [<Test>]
     let ``[1](https://github.com/fsprojects/FSharp.Quotations.Evaluator/issues/26)`` () =


### PR DESCRIPTION
Attempt to address issue #27.

There were some version issues. Using QuoteRaw/QuoteTyped didn't seem to be an option so `#nowarn "44"` (obsolete warning) and `Patterns.Quote` is used. The needed `Expr` type (`Expr` or `Expr<_>`) is determined using `inp.Type`