### PR TITLE
Remove generation of IfThen. Fixes #39

### DIFF
--- a/src/FSharp.Quotations.Evaluator/QuotationsEvaluator.fs
+++ b/src/FSharp.Quotations.Evaluator/QuotationsEvaluator.fs
@@ -397,9 +397,7 @@ module QuotationEvaluationTypes =
              build tupTy argsP |> asExpr
 
         | Patterns.IfThenElse(g,t,e) -> 
-            match e with
-            | Patterns.Value(o,_) when o = null -> Expression.IfThen (ConvExpr env g, ConvExpr env t)|> asExpr
-            | _ -> Expression.Condition(ConvExpr env g, ConvExpr env t,ConvExpr env e) |> asExpr
+            Expression.Condition(ConvExpr env g, ConvExpr env t,ConvExpr env e) |> asExpr
 
         | Patterns.Sequential (e1,e2) -> 
             let e1P = ConvExpr env e1

--- a/tests/FSharp.Quotations.Evaluator.Tests/Tests.fs
+++ b/tests/FSharp.Quotations.Evaluator.Tests/Tests.fs
@@ -1494,3 +1494,8 @@ module GithubIssues =
     let ``[5](https://github.com/fsprojects/FSharp.Quotations.Evaluator/issues/37)`` () =
         let _f = <@ fun () -> let mutable x = 0 in x <- 42 @>.Evaluate()
         ()
+
+    [<Fact>]
+    let ``[6](https://github.com/fsprojects/FSharp.Quotations.Evaluator/issues/39)`` () =
+        let t = <@ if 1 = 1 then () else (if 1 = 1 then ()) @>
+        Assert.Equal((), t.Evaluate())


### PR DESCRIPTION
This may be the wrong solution as I don't know why it was originally generating an `Expression.IfThen`, but it seems to work and all the unit tests still pass.

The reason that I made this change is that `Expression.IfThen` returns an expression of type `void` when we should really be returning an expression of type `unit`.